### PR TITLE
Catch exceptions when emitting records

### DIFF
--- a/lib/fluent/plugin/in_systemd.rb
+++ b/lib/fluent/plugin/in_systemd.rb
@@ -29,6 +29,7 @@ module Fluent
       @running = true
       pos_writer.start
       @thread = Thread.new(&method(:run))
+      @thread.abort_on_exception = true
     end
 
     def shutdown
@@ -55,7 +56,11 @@ module Fluent
 
     def run
       watch do |entry|
-        router.emit(tag, entry.realtime_timestamp.to_i, formatted(entry))
+        begin
+          router.emit(tag, entry.realtime_timestamp.to_i, formatted(entry))
+        rescue => e
+          log.error("Exception emitting record: #{e}")
+        end
       end
     end
 

--- a/lib/fluent/plugin/in_systemd.rb
+++ b/lib/fluent/plugin/in_systemd.rb
@@ -29,7 +29,6 @@ module Fluent
       @running = true
       pos_writer.start
       @thread = Thread.new(&method(:run))
-      @thread.abort_on_exception = true
     end
 
     def shutdown
@@ -55,6 +54,7 @@ module Fluent
     end
 
     def run
+      Thread.current.abort_on_exception = true
       watch do |entry|
         begin
           router.emit(tag, entry.realtime_timestamp.to_i, formatted(entry))


### PR DESCRIPTION
So the thread emitting them doesn't die. Also kill the process if the runner thread dies for some reason.

Closes #14
