### PR TITLE
Migrate to v0.14 API

### DIFF
--- a/fluent-plugin-systemd.gemspec
+++ b/fluent-plugin-systemd.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "test-unit", "~> 2.5"
   spec.add_development_dependency "reevoocop"
 
-  spec.add_runtime_dependency "fluentd", "~> 0.12"
+  spec.add_runtime_dependency "fluentd", [">= 0.14.11", "< 2"]
   spec.add_runtime_dependency "systemd-journal", "~> 1.2"
 end

--- a/lib/fluent/plugin/in_systemd.rb
+++ b/lib/fluent/plugin/in_systemd.rb
@@ -2,7 +2,8 @@ require "systemd/journal"
 require "fluent/plugin/input"
 require "fluent/plugin/systemd/pos_writer"
 
-module Fluent::Plugin
+module Fluent
+  module Plugin
   class SystemdInput < Input
     Fluent::Plugin.register_input("systemd", self)
 
@@ -83,5 +84,6 @@ module Fluent::Plugin
         end
       end
     end
+  end
   end
 end

--- a/lib/fluent/plugin/in_systemd.rb
+++ b/lib/fluent/plugin/in_systemd.rb
@@ -62,7 +62,7 @@ module Fluent::Plugin
       Thread.current.abort_on_exception = true
       watch do |entry|
         begin
-          router.emit(@tag, entry.realtime_timestamp.to_i, formatted(entry))
+          router.emit(@tag, Fluent::EventTime.from_time(entry.realtime_timestamp), formatted(entry))
         rescue => e
           log.error("Exception emitting record: #{e}")
         end

--- a/lib/fluent/plugin/in_systemd.rb
+++ b/lib/fluent/plugin/in_systemd.rb
@@ -4,86 +4,86 @@ require "fluent/plugin/systemd/pos_writer"
 
 module Fluent
   module Plugin
-  class SystemdInput < Input
-    Fluent::Plugin.register_input("systemd", self)
+    class SystemdInput < Input
+      Fluent::Plugin.register_input("systemd", self)
 
-    config_param :path, :string, default: "/var/log/journal"
-    config_param :filters, :array, default: []
-    config_param :pos_file, :string, default: nil
-    config_param :read_from_head, :bool, default: false
-    config_param :strip_underscores, :bool, default: false
-    config_param :tag, :string
+      config_param :path, :string, default: "/var/log/journal"
+      config_param :filters, :array, default: []
+      config_param :pos_file, :string, default: nil
+      config_param :read_from_head, :bool, default: false
+      config_param :strip_underscores, :bool, default: false
+      config_param :tag, :string
 
-    def configure(conf)
-      super
-      @pos_writer = PosWriter.new(@pos_file)
-      @journal = Systemd::Journal.new(path: @path)
-      @journal.filter(*@filters)
-      seek
-    end
+      def configure(conf)
+        super
+        @pos_writer = PosWriter.new(@pos_file)
+        @journal = Systemd::Journal.new(path: @path)
+        @journal.filter(*@filters)
+        seek
+      end
 
-    def start
-      super
-      @running = true
-      @pos_writer.start
-      @thread = Thread.new(&method(:run))
-    end
+      def start
+        super
+        @running = true
+        @pos_writer.start
+        @thread = Thread.new(&method(:run))
+      end
 
-    def shutdown
-      super
-      @running = false
-      @thread.join
-      @pos_writer.shutdown
-    end
+      def shutdown
+        super
+        @running = false
+        @thread.join
+        @pos_writer.shutdown
+      end
 
-    private
+      private
 
-    def seek
-      seek_to(@pos_writer.cursor || read_from)
-    rescue Systemd::JournalError
-      log.warn("Could not seek to cursor #{@pos_writer.cursor} found in pos file: #{@pos_writer.path}")
-      seek_to(read_from)
-    end
+      def seek
+        seek_to(@pos_writer.cursor || read_from)
+      rescue Systemd::JournalError
+        log.warn("Could not seek to cursor #{@pos_writer.cursor} found in pos file: #{@pos_writer.path}")
+        seek_to(read_from)
+      end
 
-    # according to https://github.com/ledbettj/systemd-journal/issues/64#issuecomment-271056644
-    # and https://bugs.freedesktop.org/show_bug.cgi?id=64614, after doing a seek(:tail),
-    # you must move back in such a way that the next move_next will return the last
-    # record
-    def seek_to(pos)
-      @journal.seek(pos)
-      return unless pos == :tail
-      @journal.move(-2)
-    end
+      # according to https://github.com/ledbettj/systemd-journal/issues/64#issuecomment-271056644
+      # and https://bugs.freedesktop.org/show_bug.cgi?id=64614, after doing a seek(:tail),
+      # you must move back in such a way that the next move_next will return the last
+      # record
+      def seek_to(pos)
+        @journal.seek(pos)
+        return unless pos == :tail
+        @journal.move(-2)
+      end
 
-    def read_from
-      @read_from_head ? :head : :tail
-    end
+      def read_from
+        @read_from_head ? :head : :tail
+      end
 
-    def run
-      Thread.current.abort_on_exception = true
-      watch do |entry|
-        begin
-          router.emit(@tag, Fluent::EventTime.from_time(entry.realtime_timestamp), formatted(entry))
-        rescue => e
-          log.error("Exception emitting record: #{e}")
+      def run
+        Thread.current.abort_on_exception = true
+        watch do |entry|
+          begin
+            router.emit(@tag, Fluent::EventTime.from_time(entry.realtime_timestamp), formatted(entry))
+          rescue => e
+            log.error("Exception emitting record: #{e}")
+          end
+        end
+      end
+
+      def formatted(entry)
+        return entry.to_h unless @strip_underscores
+        Hash[entry.to_h.map { |k, v| [k.gsub(/\A_+/, ""), v] }]
+      end
+
+      def watch
+        while @running
+          next unless @journal.wait(1_000_000)
+          while @journal.move_next && @running
+            yield @journal.current_entry
+            @pos_writer.update(@journal.cursor)
+          end
         end
       end
     end
-
-    def formatted(entry)
-      return entry.to_h unless @strip_underscores
-      Hash[entry.to_h.map { |k, v| [k.gsub(/\A_+/, ""), v] }]
-    end
-
-    def watch
-      while @running
-        next unless @journal.wait(1_000_000)
-        while @journal.move_next && @running
-          yield @journal.current_entry
-          @pos_writer.update(@journal.cursor)
-        end
-      end
-    end
-  end
   end
 end

--- a/lib/fluent/plugin/in_systemd.rb
+++ b/lib/fluent/plugin/in_systemd.rb
@@ -1,8 +1,8 @@
 require "systemd/journal"
-require "fluent/input"
+require "fluent/plugin/input"
 require "fluent/plugin/systemd/pos_writer"
 
-module Fluent
+module Fluent::Plugin
   class SystemdInput < Input
     Fluent::Plugin.register_input("systemd", self)
 

--- a/lib/fluent/plugin/systemd/pos_writer.rb
+++ b/lib/fluent/plugin/systemd/pos_writer.rb
@@ -1,6 +1,7 @@
 require "fluent/plugin/input"
 
-module Fluent::Plugin
+module Fluent
+  module Plugin
   class SystemdInput < Input
     class PosWriter
       def initialize(pos_file)
@@ -56,5 +57,6 @@ module Fluent::Plugin
         end
       end
     end
+  end
   end
 end

--- a/lib/fluent/plugin/systemd/pos_writer.rb
+++ b/lib/fluent/plugin/systemd/pos_writer.rb
@@ -2,61 +2,61 @@ require "fluent/plugin/input"
 
 module Fluent
   module Plugin
-  class SystemdInput < Input
-    class PosWriter
-      def initialize(pos_file)
-        @path = pos_file
-        @lock = Mutex.new
-        @cursor = nil
-        @written_cursor = nil
-        setup
-      end
-
-      attr_reader :cursor, :path
-
-      def start
-        return unless @path
-        @running = true
-        @thread = Thread.new(&method(:work))
-      end
-
-      def shutdown
-        return unless @path
-        @running = false
-        @thread.join
-        write_pos
-      end
-
-      def update(c)
-        return unless @path
-        @lock.synchronize { @cursor = c }
-      end
-
-      private
-
-      def setup
-        return unless @path && File.exist?(@path)
-        @cursor = IO.read(@path).chomp
-      end
-
-      def work
-        while @running
-          write_pos
-          sleep 1
+    class SystemdInput < Input
+      class PosWriter
+        def initialize(pos_file)
+          @path = pos_file
+          @lock = Mutex.new
+          @cursor = nil
+          @written_cursor = nil
+          setup
         end
-      end
 
-      def write_pos
-        @lock.synchronize do
-          if @written_cursor != @cursor
-            file = File.open(@path, "w+")
-            file.print @cursor
-            file.close
-            @written_cursor = @cursor
+        attr_reader :cursor, :path
+
+        def start
+          return unless @path
+          @running = true
+          @thread = Thread.new(&method(:work))
+        end
+
+        def shutdown
+          return unless @path
+          @running = false
+          @thread.join
+          write_pos
+        end
+
+        def update(c)
+          return unless @path
+          @lock.synchronize { @cursor = c }
+        end
+
+        private
+
+        def setup
+          return unless @path && File.exist?(@path)
+          @cursor = IO.read(@path).chomp
+        end
+
+        def work
+          while @running
+            write_pos
+            sleep 1
+          end
+        end
+
+        def write_pos
+          @lock.synchronize do
+            if @written_cursor != @cursor
+              file = File.open(@path, "w+")
+              file.print @cursor
+              file.close
+              @written_cursor = @cursor
+            end
           end
         end
       end
     end
-  end
   end
 end

--- a/lib/fluent/plugin/systemd/pos_writer.rb
+++ b/lib/fluent/plugin/systemd/pos_writer.rb
@@ -1,6 +1,6 @@
-require "fluent/input"
+require "fluent/plugin/input"
 
-module Fluent
+module Fluent::Plugin
   class SystemdInput < Input
     class PosWriter
       def initialize(pos_file)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,2 +1,3 @@
 require "test/unit"
 require "fluent/test"
+require "fluent/test/driver/input"

--- a/test/plugin/systemd/test_pos_writer.rb
+++ b/test/plugin/systemd/test_pos_writer.rb
@@ -7,7 +7,7 @@ class SystemdInputTest < Test::Unit::TestCase
     pos_file = Tempfile.new("foo.pos")
     pos_file.write("cursor_value")
     pos_file.close
-    pos_writer = Fluent::SystemdInput::PosWriter.new(pos_file.path)
+    pos_writer = Fluent::Plugin::SystemdInput::PosWriter.new(pos_file.path)
     assert_equal pos_writer.cursor, "cursor_value"
     pos_file.unlink
   end
@@ -15,7 +15,7 @@ class SystemdInputTest < Test::Unit::TestCase
   def test_reading_the_cursor_when_file_does_not_exist_yet
     dir = Dir.mktmpdir("posdir")
     path = "#{dir}/foo.pos"
-    pos_writer = Fluent::SystemdInput::PosWriter.new(path)
+    pos_writer = Fluent::Plugin::SystemdInput::PosWriter.new(path)
     assert_equal pos_writer.cursor, nil
     FileUtils.rm_rf dir
   end
@@ -23,7 +23,7 @@ class SystemdInputTest < Test::Unit::TestCase
   def test_writing_the_cursor_when_file_does_not_exist_yet
     dir = Dir.mktmpdir("posdir")
     path = "#{dir}/foo.pos"
-    pos_writer = Fluent::SystemdInput::PosWriter.new(path)
+    pos_writer = Fluent::Plugin::SystemdInput::PosWriter.new(path)
     pos_writer.start
     pos_writer.update("this is the cursor")
     assert_equal pos_writer.cursor, "this is the cursor"
@@ -35,7 +35,7 @@ class SystemdInputTest < Test::Unit::TestCase
   def test_writing_the_cursor_when_the_writer_is_shutdown
     dir = Dir.mktmpdir("posdir")
     path = "#{dir}/foo.pos"
-    pos_writer = Fluent::SystemdInput::PosWriter.new(path)
+    pos_writer = Fluent::Plugin::SystemdInput::PosWriter.new(path)
     pos_writer.start
     pos_writer.update("this is the cursor")
     pos_writer.shutdown
@@ -47,7 +47,7 @@ class SystemdInputTest < Test::Unit::TestCase
     pos_file = Tempfile.new("foo.pos")
     pos_file.write("cursor_value")
     pos_file.close
-    pos_writer = Fluent::SystemdInput::PosWriter.new(pos_file.path)
+    pos_writer = Fluent::Plugin::SystemdInput::PosWriter.new(pos_file.path)
     assert_equal pos_writer.cursor, "cursor_value"
     pos_writer.start
     pos_writer.update("this is the cursor")
@@ -59,11 +59,11 @@ class SystemdInputTest < Test::Unit::TestCase
   def test_writing_and_then_reading_the_pos_roundtrip
     dir = Dir.mktmpdir("posdir")
     path = "#{dir}/foo.pos"
-    pos_writer = Fluent::SystemdInput::PosWriter.new(path)
+    pos_writer = Fluent::Plugin::SystemdInput::PosWriter.new(path)
     pos_writer.start
     pos_writer.update("this is the cursor")
     pos_writer.shutdown
-    pos_writer = Fluent::SystemdInput::PosWriter.new(path)
+    pos_writer = Fluent::Plugin::SystemdInput::PosWriter.new(path)
     assert_equal pos_writer.cursor, "this is the cursor"
     FileUtils.rm_rf dir
   end

--- a/test/plugin/test_in_systemd.rb
+++ b/test/plugin/test_in_systemd.rb
@@ -123,13 +123,19 @@ class SystemdInputTest < Test::Unit::TestCase # rubocop:disable Metrics/ClassLen
 
   def test_reading_from_head
     d = create_driver(head_config)
-    d.run(expect_emits: 1)
+    d.end_if do
+      d.events.size >= 461
+    end
+    d.run
     assert_equal 461, d.events.size
   end
 
   def test_reading_with_filters
     d = create_driver(filter_config)
-    d.run(expect_emits: 1)
+    d.end_if do
+      d.events.size >= 3
+    end
+    d.run
     assert_equal 3, d.events.size
   end
 
@@ -138,7 +144,10 @@ class SystemdInputTest < Test::Unit::TestCase # rubocop:disable Metrics/ClassLen
     file.print "s=add4782f78ca4b6e84aa88d34e5b4a9d;i=13f;b=4737ffc504774b3ba67020bc947f1bc0;m=ffadd;t=4d905e49a6291;x=9a11dd9ffee96e9f" # rubocop:disable Metrics/LineLength
     file.close
     d = create_driver(head_config)
-    d.run(expect_emits: 1)
+    d.end_if do
+      d.events.size >= 143
+    end
+    d.run
     assert_equal 143, d.events.size
   end
 
@@ -149,7 +158,10 @@ class SystemdInputTest < Test::Unit::TestCase # rubocop:disable Metrics/ClassLen
 
     # It continues as if the pos file did not exist
     d = create_driver(head_config)
-    d.run(expect_emits: 1)
+    d.end_if do
+      d.events.size >= 461
+    end
+    d.run
     assert_equal 461, d.events.size
   end
 

--- a/test/plugin/test_in_systemd.rb
+++ b/test/plugin/test_in_systemd.rb
@@ -126,7 +126,7 @@ class SystemdInputTest < Test::Unit::TestCase # rubocop:disable Metrics/ClassLen
     d.end_if do
       d.events.size >= 461
     end
-    d.run
+    d.run(timeout: 5)
     assert_equal 461, d.events.size
   end
 
@@ -135,7 +135,7 @@ class SystemdInputTest < Test::Unit::TestCase # rubocop:disable Metrics/ClassLen
     d.end_if do
       d.events.size >= 3
     end
-    d.run
+    d.run(timeout: 5)
     assert_equal 3, d.events.size
   end
 
@@ -147,7 +147,7 @@ class SystemdInputTest < Test::Unit::TestCase # rubocop:disable Metrics/ClassLen
     d.end_if do
       d.events.size >= 143
     end
-    d.run
+    d.run(timeout: 5)
     assert_equal 143, d.events.size
   end
 
@@ -161,7 +161,7 @@ class SystemdInputTest < Test::Unit::TestCase # rubocop:disable Metrics/ClassLen
     d.end_if do
       d.events.size >= 461
     end
-    d.run
+    d.run(timeout: 5)
     assert_equal 461, d.events.size
   end
 


### PR DESCRIPTION
When migrating v0.14 API, Fluentd permits to use EventTime and Integer in time part in event and it can contain nanosecond precision time.
