### PR TITLE
Display requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 [![Build Status](https://travis-ci.org/reevoo/fluent-plugin-systemd.svg?branch=master)](https://travis-ci.org/reevoo/fluent-plugin-systemd) [![Code Climate GPA](https://codeclimate.com/github/reevoo/fluent-plugin-systemd/badges/gpa.svg)](https://codeclimate.com/github/reevoo/fluent-plugin-systemd) [![Gem Version](https://badge.fury.io/rb/fluent-plugin-systemd.svg)](https://rubygems.org/gems/fluent-plugin-systemd)
 
+# Requirements <a name="requirements"></a>
+
+
+|fluent-plugin-systemd|fluentd|ruby|
+|----|----|----|
+|>= 0.1.0 | >= 0.14.11, < 2 | >= 2.1 |
+|<= 0.0.5 | ~> 0.12.0 | >= 1.9  |
+
 ## Overview
 
 **systemd** input plugin reads logs from the systemd journal


### PR DESCRIPTION
It would be nice to display requirements for v0.14 migrated Fluentd Plugins.
Fluentd users sometimes report errors about with td-agent2 and updating plugins bump up Fluentd version to v0.14 from v0.12.

How about announce requirements to users in README?

Regards,