### PR TITLE
Call get_fd() to avoid missing file rotations

### DIFF
--- a/lib/fluent/plugin/in_systemd.rb
+++ b/lib/fluent/plugin/in_systemd.rb
@@ -66,6 +66,7 @@ module Fluent
         # TODO: ruby 2.3
         @journal.close if @journal # rubocop:disable Style/SafeNavigation
         @journal = Systemd::Journal.new(path: @path)
+        @journal.get_fd()
         # make sure initial call to wait doesn't return :invalidate
         # see https://github.com/ledbettj/systemd-journal/issues/70
         @journal.wait(0)


### PR DESCRIPTION
See https://github.com/systemd/systemd/issues/7998 and https://github.com/rsyslog/rsyslog/pull/2437 for more information and background.