### PR TITLE
storage_create needs either type or conf

### DIFF
--- a/lib/fluent/plugin/in_systemd.rb
+++ b/lib/fluent/plugin/in_systemd.rb
@@ -50,7 +50,7 @@ module Fluent
       def configure(conf)
         super
         @journal = nil
-        @pos_storage = storage_create(usage: 'positions')
+        @pos_storage = storage_create(usage: 'positions', type: DEFAULT_STORAGE_TYPE)
         @mutator = SystemdEntryMutator.new(**@entry_opts.to_h)
         @mutator.warnings.each { |warning| log.warn(warning) }
       end


### PR DESCRIPTION
in both fluent 1.3.3 and 1.4.0 the function storage_create sets both type and conf to be nil by default, and expects ONE of them at least to be set or it will throw an ArgumentError, "BUG: both type and conf are not specified"

/lib/fluent/plugin_helper/storage.rb line 32: def storage_create(usage: '', type: nil, conf: nil, default_type: nil)