### PR TITLE
rescue JournalError

### DIFF
--- a/lib/fluent/plugin/in_systemd.rb
+++ b/lib/fluent/plugin/in_systemd.rb
@@ -129,6 +129,8 @@ module Fluent
 
       def watch(&block)
         yield_current_entry(&block) while @journal.move_next
+      rescue Systemd::JournalError => e
+        log.warn("Error moving to next Journal entry: #{e.class}: #{e.message}")
       end
 
       def yield_current_entry


### PR DESCRIPTION
I believe this is the fix to issue #70 

According to stack traces move_next is raising an exception. This PR should rescue and allow the plugin to continue.