### PR TITLE
Shutdown cleanly

### DIFF
--- a/lib/fluent/plugin/in_systemd.rb
+++ b/lib/fluent/plugin/in_systemd.rb
@@ -57,7 +57,13 @@ module Fluent
 
       def start
         super
+        @running = true
         timer_execute(:in_systemd_emit_worker, 1, &method(:run))
+      end
+
+      def shutdown
+        @running = false
+        super
       end
 
       private
@@ -131,7 +137,7 @@ module Fluent
       end
 
       def watch(&block)
-        yield_current_entry(&block) while @journal.move_next
+        yield_current_entry(&block) while @running && @journal.move_next
       rescue Systemd::JournalError => e
         log.warn("Error moving to next Journal entry: #{e.class}: #{e.message}")
       end


### PR DESCRIPTION
Fixes #46

If there are still entries to be read from the journal when fluend
shuts down we will continue emitting records even after the router has
been removed.

This change stops reading after the shutdown hook gets called.

It also has the nice side effect that we stop updating pos storage,
so we shouldn't miss any entries when / if we start up again.