### PR TITLE
Update rpm package test environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           file: test/docker/Dockerfile.ubuntu
-  tdagent:
+  tdagent-deb:
     runs-on: ubuntu-latest
     steps:
       -
@@ -34,7 +34,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           file: test/docker/Dockerfile.tdagent-ubuntu
-  centos:
+  tdagent-rpm:
     runs-on: ubuntu-latest
     steps:
       -
@@ -47,7 +47,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          file: test/docker/Dockerfile.tdagent-centos
+          file: test/docker/Dockerfile.tdagent-almalinux
   rubocop:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           file: test/docker/Dockerfile.ubuntu
-  tdagent:
+  tdagent-deb:
     runs-on: ubuntu-latest
     steps:
       -
@@ -32,7 +32,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           file: test/docker/Dockerfile.tdagent-ubuntu
-  centos:
+  tdagent-rpm:
     runs-on: ubuntu-latest
     steps:
       -
@@ -45,7 +45,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          file: test/docker/Dockerfile.tdagent-centos
+          file: test/docker/Dockerfile.tdagent-almalinux
   rubocop:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -212,13 +212,13 @@ On Debian or Ubuntu you might need to install the libsystemd0 package:
 apt-get install libsystemd0
 ```
 
-On CentOS or RHEL you might need to install the systemd package:
+On AlmaLinux or RHEL you might need to install the systemd package:
 
 ```
 yum install -y systemd
 ```
 
-If you want to do this in a CentOS docker image you might first need to remove the `fakesystemd` package.
+If you want to do this in a AlmaLinux docker image you might first need to remove the `fakesystemd` package.
 
 ```
 yum remove -y fakesystemd

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ task build: 'docker:test'
 task default: :rubocop
 
 namespace :docker do
-  distros = %i[ubuntu tdagent-ubuntu tdagent-centos]
+  distros = %i[ubuntu tdagent-ubuntu tdagent-almalinux]
   task test: distros
 
   distros.each do |distro|

--- a/test/docker/Dockerfile.tdagent-almalinux
+++ b/test/docker/Dockerfile.tdagent-almalinux
@@ -1,8 +1,8 @@
-FROM centos:8
+FROM almalinux:9
 
 RUN rpm --import https://packages.treasuredata.com/GPG-KEY-td-agent \
       && printf "[treasuredata]\nname=TreasureData\nbaseurl=http://packages.treasuredata.com/4/redhat/\$releasever/\$basearch\ngpgcheck=1\ngpgkey=https://packages.treasuredata.com/GPG-KEY-td-agent\n" > /etc/yum.repos.d/td.repo \
-      && yum install -y td-agent make gcc-c++ systemd
+      && dnf install -y td-agent make gcc-c++ systemd
 
 ENV PATH /opt/td-agent/bin/:$PATH
 RUN td-agent-gem install bundler


### PR DESCRIPTION
The next [td-agent](https://github.com/fluent/fluent-package-builder) will embed Ruby 3.2.

I was checking each embedded plugin, and I noticed that we should update the CI of this plugin.

I think several points need to be fixed. Please let me submit them in separate PRs.

---

This PR updates CI for the td-agent rpm package.
Since CentOS is EOL now, we should replace it with another RHEL compatible OS.

The current CI fails since the yum repository mirror site doesn't work anymore.

In addition to this PR, we need to fix some tests for the latest libsystemd.
I will submit another PR on that.
