### PR TITLE
Fix test for libsystemd v250

### DIFF
--- a/test/plugin/test_in_systemd.rb
+++ b/test/plugin/test_in_systemd.rb
@@ -262,8 +262,10 @@ class SystemdInputTest < Test::Unit::TestCase
   end
 
   def test_reading_from_a_journal_with_corrupted_entries
+    # One corrupted entry exists in 461 entries. (The 3rd entry is corrupted.)
     d = create_driver(corrupt_entries_config)
     d.run(expect_emits: 460)
-    assert_equal 460, d.events.size
+    # Since libsystemd v250, it can read this corrupted record.
+    assert { d.events.size == 460 or d.events.size == 461 }
   end
 end


### PR DESCRIPTION
This will fix the failing test in following RP.

* #100

The latest libsystemd can read some corrupted entries without errors.

Since libsystemd v250, it's specification against journal file corruption changed.

https://github.com/systemd/systemd/blob/v250/NEWS#L807-L808

* https://github.com/systemd/systemd/commit/df207ccb7be02b1ca6bdd0a2066a898e5b24ee86
* https://github.com/systemd/systemd/commit/548614cc9a1d7cb4ad84923b42a6e18591eaf5dd

In AlmaLinux9 (libsystemd v250):

```rb
require "systemd"
require "systemd/journal"
journal = Systemd::Journal.new(path: "test/fixture/corrupt")
entries = journal.to_a # Succeeds without errors
entries[2] # Before v250, it couldn't read this entry.
=> #<Systemd::JournalEntry:0x000000000003ba60 priority: '6',
_boot_id: '4737ffc504774b3ba67020bc947f1bc0', _machine_id:
'bb9d0a52a41243829ecd729b40ac0bce', _hostname: 'arch',
_source_monotonic_timestamp: '0', _transport: 'kernel',
syslog_identifier: 'kernel'>
```

Assuming both old and new libsystemd, it would be good to fix the test in this way.
