### PR TITLE
Use latest systemd-journal

### DIFF
--- a/fluent-plugin-systemd.gemspec
+++ b/fluent-plugin-systemd.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '1.13.0'
 
   spec.add_runtime_dependency 'fluentd', ['>= 0.14.11', '< 2']
-  spec.add_runtime_dependency 'systemd-journal', '~> 1.4.2'
+  spec.add_runtime_dependency 'systemd-journal', '~> 2.0.0'
 end

--- a/test/docker/Dockerfile.tdagent-ubuntu
+++ b/test/docker/Dockerfile.tdagent-ubuntu
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 RUN apt-get update -q \
       && apt-get install -qy --no-install-recommends \
@@ -8,7 +8,7 @@ RUN apt-get update -q \
         gnupg \
         libsystemd0 \
       && curl https://packages.treasuredata.com/GPG-KEY-td-agent | apt-key add - \
-      && echo "deb http://packages.treasuredata.com/4/ubuntu/focal/ focal contrib" > /etc/apt/sources.list.d/treasure-data.list \
+      && echo "deb http://packages.treasuredata.com/4/ubuntu/jammy/ jammy contrib" > /etc/apt/sources.list.d/treasure-data.list \
       && apt-get update \
       && apt-get install -y td-agent \
       && apt-get clean \

--- a/test/docker/Dockerfile.ubuntu
+++ b/test/docker/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 RUN apt-get update -q && apt-get install -qy --no-install-recommends \
         build-essential \


### PR DESCRIPTION
There is known bug that systemd-journal 1.4.2 or older version doesn't work with custom memory allocator such as jemalloc because of inappropriate allocated memory handling.
As a result, it causes a SEGV. This bug was frequently reported from fluent-docker-image and fluentd-kubernetes-daemonset images users. [1]

[1] https://github.com/fluent/fluentd-docker-image/issues/378

Recently, this bug was fixed [2] and released as systemd-journal 2.0.0. Now we should switch to it.

[2] https://github.com/ledbettj/systemd-journal/pull/97

NOTE: systemd-journal 2.0.0 requires Ruby 3.0.0 or later, so need to bump base image version which provides Ruby 3.x - so use ubuntu:jammy for testing.