### PR TITLE
Allow executing without sudo

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ namespace :docker do
   distros.each do |distro|
     task distro do
       puts "testing on #{distro}"
-      sh "sudo docker build . -f test/docker/Dockerfile.#{distro}"
+      sh "docker build . -f test/docker/Dockerfile.#{distro}"
     end
   end
 end


### PR DESCRIPTION
When release manager (gem owner) want to execute rake release, it is assumed to be executed via sudo.

If owner already belongs to docker group, it fails.